### PR TITLE
Fix for the author cache

### DIFF
--- a/gitcovery/author.py
+++ b/gitcovery/author.py
@@ -70,7 +70,7 @@ class Author(object):
         """
         if cls._authors:
             return
-        out = Git.call(['log', '--format=%aN%n%aE%n%cN%n%cE%n%H%n'])
+        out = Git.call(['log', '--all', '--format=%aN%n%aE%n%cN%n%cE%n%H%n'])
 
         def register(name, email):
             if name not in cls._authors:
@@ -111,7 +111,12 @@ class Author(object):
         name = name.strip()
         cls._load_authors()
 
+        # If not known, try reload
         if name not in cls._authors:
+            cls._load_authors()
+
+        # If already reloaded and still not found, throw exception
+        if cls._authors[name] is None:
             raise Exception(
                 'Author <%s> not known' % name)
 

--- a/gitcovery/commit.py
+++ b/gitcovery/commit.py
@@ -61,30 +61,34 @@ class Commit(object):
                 'git show output could not be matched for: %s\n' % self.sha +
                 'Please report the commit hash and repository so I can improve the regex')
 
-        # Parse parents
-        for sha in matcher.group('parents').split(' '):
-            if sha == '':
-                continue
-            self._parents.append(self.get_commit(sha))
+        try:
+            # Parse parents
+            for sha in matcher.group('parents').split(' '):
+                if sha == '':
+                    continue
+                self._parents.append(self.get_commit(sha))
 
-        # Parse authors
-        self._author = Author.get_author(matcher.group('author'), email=matcher.group('authorMail'))
-        self._commit = Author.get_author(matcher.group('commit'), email=matcher.group('commitMail'))
+            # Parse authors
+            self._author = Author.get_author(matcher.group('author'), email=matcher.group('authorMail'))
+            self._commit = Author.get_author(matcher.group('commit'), email=matcher.group('commitMail'))
 
-        self._author.register_commit(self)
+            self._author.register_commit(self)
 
-        self._authorDate = dp.parse(matcher.group('authorDate'))
-        self._commitDate = dp.parse(matcher.group('commitDate'))
+            self._authorDate = dp.parse(matcher.group('authorDate'))
+            self._commitDate = dp.parse(matcher.group('commitDate'))
 
-        # Parse the commit contents
-        self._title = matcher.group('title')
-        self._msg = matcher.group('message').strip() if matcher.group('message') else ''
+            # Parse the commit contents
+            self._title = matcher.group('title')
+            self._msg = matcher.group('message').strip() if matcher.group('message') else ''
 
-        # Parse the diff if provided
-        if load_diff:
-            self._diff = Diff(matcher.group('diff'))
-        else:
-            self._diff = None
+            # Parse the diff if provided
+            if load_diff:
+                self._diff = Diff(matcher.group('diff'))
+            else:
+                self._diff = None
+        except Exception as e:
+            raise Exception('Cannot construct commit %s from the given output' % self.sha +
+                            'Please report the commit hash and repository so I can fix the problem', e)
 
     def _load_diff(self):
         """


### PR DESCRIPTION
The fixed problem surfaced when the author cache was created on an old revision.
In this case, loading a future commit with a new author would result in an 'author unknown' error.

This is fixed now